### PR TITLE
footer.html の app.js の参照削除

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -29,5 +29,3 @@
 </footer>
 
 {{ partial "svg" . }}
-
-<script src="/app.js"></script>


### PR DESCRIPTION
app.js は特に使用していないようでしたので、footer.html から script タグを削除しました。